### PR TITLE
Output console logging to stderr for `render`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/node';
 import dotenv from 'dotenv';
 import yargsInit from 'yargs';
 
+import * as logging from './logging';
 import {renderServer} from './renderServer';
 import {renderStream} from './renderStream';
 import {resolveStylesConfig} from './stylesLoader';
@@ -31,7 +32,9 @@ yargsInit(process.argv.slice(2))
         .coerce('port', Number);
     },
     async argv => {
+      logging.registerConsoleLogger();
       const styles = await resolveStylesConfig(argv.styles);
+
       renderServer({styles, port: argv.port as number});
     }
   )
@@ -40,7 +43,11 @@ yargsInit(process.argv.slice(2))
     'renders a chart from a valid JSON input',
     () => {},
     async argv => {
+      // All logging output needs to happen over stderr, otherwise we'll
+      // pollute the image output produced when rendering a chart.
+      logging.registerConsoleLogger({stderrLevels: ['error', 'info', 'debug']});
       const styles = await resolveStylesConfig(argv.styles);
+
       renderStream(styles);
     }
   )

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -3,11 +3,16 @@ import {createLogger, format, transports} from 'winston';
 export const logger = createLogger({
   level: 'info',
   format: format.json(),
-  transports: [],
+  transports: [
+    // TODO: What transports need to go into here in production?
+  ],
 });
 
-if (process.env.NODE_ENV !== 'production') {
-  logger.add(
-    new transports.Console({format: format.combine(format.colorize(), format.simple())})
-  );
+export function registerConsoleLogger(options?: transports.ConsoleTransportOptions) {
+  const transport = new transports.Console({
+    format: format.combine(format.colorize(), format.simple()),
+    ...options,
+  });
+
+  logger.add(transport);
 }


### PR DESCRIPTION
When rendering via std{in,out} we have to be careful not to write out anythings else to stdout.